### PR TITLE
Use card view page to easier edit survivors not in the party

### DIFF
--- a/src/components/GearGrid.tsx
+++ b/src/components/GearGrid.tsx
@@ -9,7 +9,6 @@ import { SetPlayerNameAction, ShowLayerAction } from "../interfaces/actions";
 import { colors } from "../theme";
 import AffinityIcon from "./AffinityIcon";
 import GridSlot from "./GridSlot";
-import Link from "./Link";
 import NameEdit from "./NameEdit";
 import { Card, StyledText } from "./StyledComponents";
 import SurvivorCard from "./SurvivorCard";
@@ -47,6 +46,18 @@ const mapStateToProps = (state: IState, ownProps: IGearGridOwnProps): IGearGridS
     };
 };
 
+export const PlayerCard = styled.div`
+    max-width: 80%;
+    margin: 0 auto;
+    `;
+
+export const PlayerCardHeadline = styled.div`
+    color: ${colors.text};
+    font-weight:bold;
+    text-align:center;
+    margin:.5vh 0;
+`;
+
 class GearGrid extends React.Component<IGearGridProps, IGearGridState> {
     public constructor(props: IGearGridProps) {
         super(props);
@@ -54,21 +65,12 @@ class GearGrid extends React.Component<IGearGridProps, IGearGridState> {
     }
 
     public render() {
-        const PlayerCard = styled.div`
-            max-width: 80%;
-            margin: 0 auto;
-        `;
+
         const StyledGrid = styled(Card)`
             display:flex;
             flex-wrap:wrap;
             width:100%;
             margin: 1vh 0;
-        `;
-        const PlayerCardHeadline = styled.div`
-            color: ${colors.text};
-            font-weight:bold;
-            text-align:center;
-            margin:.5vh 0;
         `;
         const GridAffinities = styled.div`
             display:flex;
@@ -87,7 +89,6 @@ class GearGrid extends React.Component<IGearGridProps, IGearGridState> {
                 <PlayerCard>
                     <PlayerCardHeadline>
                         <div>Player: <NameEdit name={grid.playername || "not assigned"} updateFunc={this.handleSetPlayerName} /> </div>
-                        <Link to={`/card/${id}`}>Open slot on own page</Link>
                     </PlayerCardHeadline>
                     {typeof grid.survivorId !== "undefined" && <SurvivorCard key={grid.id} id={grid.survivorId} />}
                     <GridAffinities>

--- a/src/components/SurvivorListItem.tsx
+++ b/src/components/SurvivorListItem.tsx
@@ -9,6 +9,7 @@ import { AddToHuntAction, KillSurvivorAction, RemoveFromHuntAction, RemoveSurviv
 import { colors } from "../theme";
 import { capitalize, clone, darken } from "../util";
 import GenderEdit from "./GenderEdit";
+import Link from "./Link";
 import NameEdit from "./NameEdit";
 import { colorMagentaLachs, FancyButton } from "./StyledComponents";
 import SurvivorBaseStat from "./SurvivorBaseStat";
@@ -86,6 +87,10 @@ const SmallSpaceLabel = styled.div`
     }
 `;
 
+const FullscreenLink = styled(Link)`
+    text-decoration: none;
+`;
+
 const mapDispatchToProps = (dispatch: Dispatch<AddToHuntAction | RemoveFromHuntAction | KillSurvivorAction | ReviveSurvivorAction | UpdateSurvivorNameAction | RemoveSurvivorAction>): ISurvivorListItemDispatchProps => ({
     addToHunt: (id: ID, gridId: number) => dispatch(addToHunt(id, gridId)),
     killSurvivor: (id: ID) => dispatch(killSurvivor(id)),
@@ -133,6 +138,7 @@ class SurvivorListItem extends Component<ISurvivorListItemProps> {
                         <SmallSpaceLabel>Name</SmallSpaceLabel>
                         <NameEdit name={name} updateFunc={this.handleNameUpdate} />
                         {!alive && <Fragment>✝</Fragment>}
+                        <FullscreenLink to={`/card/${id}`}>⛶</FullscreenLink>
                     </NameCell>
                     <Cell>
                         <SmallSpaceLabel>Gender</SmallSpaceLabel>

--- a/src/pages/suvivorcard.tsx
+++ b/src/pages/suvivorcard.tsx
@@ -1,7 +1,8 @@
-import { ID, UUID } from "interfaces";
 import React from "react";
 import { RouteComponentProps } from "react-router";
-import GearGrid from "../components/GearGrid";
+import { PlayerCard, PlayerCardHeadline } from "../components/GearGrid";
+import Link from "../components/Link";
+import SurvivorCard from "../components/SurvivorCard";
 
 interface IPageMatchParams {
     cardnumber: string;
@@ -13,9 +14,13 @@ class SurvivorCardPage extends React.Component<ISurvivorCardPageProps> {
     public render() {
         const { match } = this.props;
         return (
-            <React.Fragment>
-                <GearGrid id={parseInt(match.params.cardnumber, 10) as ID} />
-            </React.Fragment>);
+            <PlayerCard>
+                <PlayerCardHeadline>
+                <Link to={`/`}>Back to overview</Link>
+                </PlayerCardHeadline>
+                <SurvivorCard id={parseInt(match.params.cardnumber, 10)} />
+            </PlayerCard>
+            );
     }
 }
 


### PR DESCRIPTION
The current /card/ route doesn't really do anything useful as the new tabbed interface completely replaces the functionality.
This change adds a new Icon to the survivor list that allows easier editing of all survivors even if they are not currently in our party.